### PR TITLE
feat: 질문 목록 불러오기

### DIFF
--- a/front_src/src/api/Question.ts
+++ b/front_src/src/api/Question.ts
@@ -1,0 +1,7 @@
+export interface Question {
+    questionId: string;
+    content: string;
+    title: string;
+    userId: string;
+    createdAt?: string;
+}

--- a/front_src/src/assets/ts/QnAPage.ts
+++ b/front_src/src/assets/ts/QnAPage.ts
@@ -1,10 +1,11 @@
 import { useRouter } from "vue-router";
 import {ref, onMounted} from "vue";
 import axios from "axios";
+import {Question} from "@/api/Question"
 
 export default function useQnAPage() {
     const router = useRouter();
-    const questions = ref([]);
+    const questions = ref<Question[]>([]);
 
     const category = ref("IT");
     const offset = ref(0);
@@ -12,10 +13,18 @@ export default function useQnAPage() {
 
     const fetchQuestions = async () => {
         try {
-            const response = await axios.get("/v1/api/rag/questions/titles", {
+            const response = await axios.get<Question[]>("/v1/api/rag/questions/titles", {
                 params: {category: category.value, offset: offset.value, limit: limit.value}
             });
-            questions.value = response.data;
+
+            console.log("백엔드 응답: ", response.data);
+            questions.value = response.data.map((q:Question) => ({
+                questionId: q.questionId,
+                content: q.content,
+                title: q.title,
+                userId: q.userId,
+                createdAt: q.createdAt
+            }));
         }catch(error) {
             console.error("질문을 불러올 수 없습니다.", error);
         }

--- a/front_src/src/assets/ts/QuestionViewComponent.ts
+++ b/front_src/src/assets/ts/QuestionViewComponent.ts
@@ -1,18 +1,50 @@
 import { computed } from "vue";
 import { useRouter } from "vue-router";
+import {Question} from "@/api/Question"
 
 export default function useQuestionView(props: {question: any}) {
     const router = useRouter();
 
-    const goToDetailView = () => {
-        router.push("qna/number");
-    }
+    const goToDetailView = (question: Question) => {
+        if (!question) {
+            alert("선택된 질문이 없습니다.");
+            return;
+        }
+        alert(`유저 아이디: ${question.userId}\n제목: ${question.title}\n작성 날짜: ${question.createdAt}\n내용: ${question.content}`);
+        router.push("/qna/number");
+    };
 
 
     const formattedDate = computed(() => {
-        const date = new Date(props.question.createdAt);
-        return date.toLocaleString("ko-KR", { dateStyle: "full", timeStyle: "short" });
-    })
+        const { createdAt } = props.question;
+    
+        // createdAt이 존재하지 않거나 유효하지 않으면 기본값 반환
+        if (!createdAt) {
+            return "날짜 정보가 없습니다.";
+        }
+    
+        const date = new Date(createdAt);
+    
+        // 유효한 날짜인지 확인
+        if (isNaN(date.getTime())) {
+            return "잘못된 날짜입니다.";
+        }
+    
+        // 날짜를 원하는 포맷으로 직접 처리
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');  // 월은 0부터 시작하므로 +1
+        const day = String(date.getDate()).padStart(2, '0');
+        const hours = date.getHours();
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        
+        // 오전/오후 계산
+        const ampm = hours >= 12 ? "오후" : "오전";
+        const hourIn12HourFormat = hours > 12 ? hours - 12 : hours;
+        const formattedHour = String(hourIn12HourFormat).padStart(2, '0');
+    
+        return `${year}.${month}.${day}. ${ampm} ${formattedHour}:${minutes}`;
+    });
+    
 
     return{goToDetailView, formattedDate};
 }

--- a/front_src/src/components/QuestionViewComponent.vue
+++ b/front_src/src/components/QuestionViewComponent.vue
@@ -1,34 +1,36 @@
 <template>
-    <div class="q_block" @click="goToDetailView">
+    <div class="q_block" @click="goToDetailView(question)">
         <div class="profile_box">
             <div class="profile_pic"></div>
             <div class="user_nickname">
-                <p>{{ question.nickname }}</p>
+                <p>{{ question?.userId }}</p>
             </div>
         </div>
         <div class="content_box">
-            <p class="title">{{ question.title }}</p>
+            <p class="title">{{ question?.title }}</p>
             <p class="time">{{ formattedDate }}</p>
-            <p class="body">{{ question.body }}</p>
+            <p class="body">{{ question?.content }}</p>
         </div>
     </div>
 </template>
 
 <script lang="ts">
-import {defineComponent} from "vue";
+import {defineComponent, PropType} from "vue";
 import "../assets/css/QuestionViewComponent.css";
 import useQuestionView from "@/assets/ts/QuestionViewComponent";
+import { Question } from "@/api/Question";
 
 export default defineComponent({
     name: "QuestionViewComponent",
     props: {
         question: {
-            type: Object,
+            type: Object as PropType<Question>,
             required: true
         }
     },
     setup(props) {
-        return useQuestionView(props);
-    }
+        const { goToDetailView, formattedDate } = useQuestionView(props);
+        return { goToDetailView, formattedDate };
+    },
 })
 </script>

--- a/front_src/src/views/QnAPage.vue
+++ b/front_src/src/views/QnAPage.vue
@@ -4,7 +4,7 @@
             <div class="q_list">
                 <QuestionViewComponent
                     v-for="question in questions"
-                    :key="question.question_id"
+                    :key="question.questionId"
                     :question="question"
                 />
             </div>
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts">
-import {defineComponent} from "vue";
+import {defineComponent, PropType} from "vue";
 import "../assets/css/QnAPage.css";
 import QuestionViewComponent from "@/components/QuestionViewComponent.vue";
 import useQnAPage from "@/assets/ts/QnAPage";
@@ -31,6 +31,13 @@ export default defineComponent({
     setup() {
         const {questions, goToWriteQuestion} = useQnAPage();
         return {questions, goToWriteQuestion};
+    },
+    props: {
+        question: {
+            type: Object as PropType<{ questionId: string; content: string; title: string; userId: string }>,
+            required: true
+        }
     }
+    
 });
 </script>


### PR DESCRIPTION
Done
- Header의 질의응답 div 클릭하면 "IT" 태그를 가진 질문 목록이 조회됨

ToDo
- 프론트 코드에서 태그 값을 "IT"로 임의로 지정하여 백서버에 요청을 보냈기 때문에, 전체 목록 조회가 가능하도록 코드를 수정해야 함

Issue
1. 목록을 불러올 때 UI에서 content 중 일부를 미리 보여주도록 UI 디자인을 해두었는데, 백서버에서 받아오는 데이터를 console.log로 찍어 확인해보니 content 값을 받아오지 않음
2. 전체 목록 조회를 어떻게 구현할 것인가